### PR TITLE
fix(mirakc::command_util): wait for the command pipeline termination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,6 +1046,7 @@ dependencies = [
  "log 0.4.14",
  "mustache",
  "num_cpus",
+ "once_cell",
  "serde",
  "serde_json",
  "serde_qs",

--- a/mirakc-core/Cargo.toml
+++ b/mirakc-core/Cargo.toml
@@ -21,6 +21,7 @@ libc = "0.2.87"
 log = "0.4.14"
 mustache = "0.9.0"
 num_cpus = "1.13.0"
+once_cell = "1.7.2"
 serde = { version = "1.0.124", features = ["derive", "rc"] }
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
 serde_yaml = "0.8.17"

--- a/mirakc-core/src/command_util.rs
+++ b/mirakc-core/src/command_util.rs
@@ -358,12 +358,6 @@ mod tests {
     use assert_matches::assert_matches;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    #[test]
-    fn test_command_pipeline_termination_wait_nanos() {
-        let _ = env::set_var("MIRAKC_COMMAND_PIPELINE_TERMINATION_WAIT_NANOS", "1");
-        assert_eq!(*COMMAND_PIPELINE_TERMINATION_WAIT_NANOS, Duration::from_nanos(1));
-    }
-
     #[tokio::test]
     async fn test_spawn_process() {
         let result = spawn_process("sh -c 'exit 0;'", Stdio::null());


### PR DESCRIPTION
this PR fixes #186