### PR TITLE
feat(mirakc): auto-migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,7 @@ dependencies = [
  "clap",
  "humantime",
  "mirakc-core",
+ "semver",
  "serde_json",
  "serde_yaml",
  "tempfile",
@@ -1837,6 +1838,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"

--- a/mirakc-core/src/lib.rs
+++ b/mirakc-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod command_util;
 pub mod config;
 pub mod epg;
 pub mod error;
+pub mod file_util;
 pub mod filter;
 pub mod models;
 pub mod mpeg_ts_stream;
@@ -19,4 +20,3 @@ pub mod tuner;
 pub mod web;
 
 mod events;
-mod file_util;

--- a/mirakc/Cargo.toml
+++ b/mirakc/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "4.5.28", features = ["derive", "env"] }
 chrono = { version = "0.4.39", default-features = false, features = ["clock", "serde"] }
 humantime = "2.1.0"
 mirakc-core = { path = "../mirakc-core" }
+semver = "1.0.25"
 serde_json = { version = "1.0.138", features = ["preserve_order"] }
 tempfile = "3.16.0"
 tokio = { version = "1.43.0", features = ["full"] }

--- a/mirakc/src/migrate/mod.rs
+++ b/mirakc/src/migrate/mod.rs
@@ -1,0 +1,15 @@
+mod v4;
+
+use mirakc_core::*;
+
+/// Migrate existing data to the new data format.
+#[derive(clap::Args, Default)]
+pub struct CommandLine {
+    /// Always perform the migration.
+    #[arg(short, long)]
+    force: bool,
+}
+
+pub async fn main(config: &config::Config, cl: &CommandLine) {
+    v4::migrate(config, cl);
+}

--- a/mirakc/src/migrate/v4/mod.rs
+++ b/mirakc/src/migrate/v4/mod.rs
@@ -1,0 +1,86 @@
+#[cfg(test)]
+mod tests;
+
+use super::*;
+
+use std::collections::HashMap;
+
+pub fn migrate(config: &config::Config, cl: &CommandLine) {
+    migrate_recording_schedules(config, cl);
+}
+
+pub fn migrate_recording_schedules(config: &config::Config, cl: &CommandLine) -> bool {
+    let basedir = match config.recording.basedir.as_ref() {
+        Some(basedir) => basedir,
+        None => {
+            tracing::info!("The recording feature is disabled");
+            return false;
+        }
+    };
+
+    let old_path = basedir.join("schedules.json");
+    if !old_path.is_file() {
+        tracing::info!(file = %old_path.display(), "File not found");
+        return false;
+    }
+
+    let new_path = basedir.join("schedules.v1.json");
+    if !cl.force && new_path.is_file() {
+        tracing::info!(file = %new_path.display(), "Already migrated");
+        return false;
+    }
+
+    let epg_cache_dir = match config.epg.cache_dir.as_ref() {
+        Some(epg_cache_dir) => epg_cache_dir,
+        None => {
+            tracing::error!("No EGP data");
+            return false;
+        }
+    };
+
+    let services: Vec<(models::ServiceId, epg::EpgService)> = {
+        let path = epg_cache_dir.join("services.json");
+        if !path.is_file() {
+            tracing::error!(file = %path.display(), "No EPG data");
+            return false;
+        }
+        let file = std::fs::File::open(path).unwrap();
+        serde_json::from_reader(file).unwrap()
+    };
+
+    let service_map: HashMap<models::ServiceId, epg::EpgService> = HashMap::from_iter(services);
+
+    let mut schedules: serde_json::Value = {
+        let file = std::fs::File::open(&old_path).unwrap();
+        serde_json::from_reader(file).unwrap()
+    };
+
+    tracing::info!(
+        file = %old_path.display(),
+        reason = "feat(recording)!: add `RecordingSchedule.service`",
+        commit = "b4e324db670947dfdd056402faaa7bcedcc2e4dc",
+        "Migrating...",
+    );
+    for sched in schedules.as_array_mut().unwrap().iter_mut() {
+        let program_id = sched["program"]["id"].clone();
+        let program_id: models::ProgramId = serde_json::from_value(program_id).unwrap();
+        let service_id = program_id.into();
+        let service = match service_map.get(&service_id) {
+            Some(service) => service,
+            None => {
+                tracing::error!(%service_id, "No such service");
+                return false;
+            }
+        };
+        sched["service"] = serde_json::to_value(service).unwrap();
+        tracing::debug!(?program_id, "Updated the recording schedule");
+    }
+
+    if file_util::save_json(&schedules, &new_path) {
+        tracing::info!("Migrated successfully");
+        true
+    } else {
+        tracing::error!(?new_path, "Failed to save");
+        false
+    }
+}

--- a/mirakc/src/migrate/v4/mod.rs
+++ b/mirakc/src/migrate/v4/mod.rs
@@ -20,13 +20,13 @@ pub fn migrate_recording_schedules(config: &config::Config, cl: &CommandLine) ->
 
     let old_path = basedir.join("schedules.json");
     if !old_path.is_file() {
-        tracing::info!(file = %old_path.display(), "File not found");
+        tracing::info!(file = ?old_path, "File not found");
         return false;
     }
 
     let new_path = basedir.join("schedules.v1.json");
     if !cl.force && new_path.is_file() {
-        tracing::info!(file = %new_path.display(), "Already migrated");
+        tracing::info!(file = ?new_path, "Already migrated");
         return false;
     }
 
@@ -41,7 +41,7 @@ pub fn migrate_recording_schedules(config: &config::Config, cl: &CommandLine) ->
     let services: Vec<(models::ServiceId, epg::EpgService)> = {
         let path = epg_cache_dir.join("services.json");
         if !path.is_file() {
-            tracing::error!(file = %path.display(), "No EPG data");
+            tracing::error!(needed = ?path, "No EPG data");
             return false;
         }
         let file = std::fs::File::open(path).unwrap();
@@ -56,7 +56,7 @@ pub fn migrate_recording_schedules(config: &config::Config, cl: &CommandLine) ->
     };
 
     tracing::info!(
-        file = %old_path.display(),
+        file = ?old_path,
         reason = "feat(recording)!: add `RecordingSchedule.service`",
         commit = "b4e324db670947dfdd056402faaa7bcedcc2e4dc",
         "Migrating...",
@@ -77,7 +77,7 @@ pub fn migrate_recording_schedules(config: &config::Config, cl: &CommandLine) ->
     }
 
     if file_util::save_json(&schedules, &new_path) {
-        tracing::info!("Migrated successfully");
+        tracing::info!(?old_path, ?new_path, "Migrated successfully");
         true
     } else {
         tracing::error!(?new_path, "Failed to save");

--- a/mirakc/src/migrate/v4/tests/mod.rs
+++ b/mirakc/src/migrate/v4/tests/mod.rs
@@ -1,0 +1,182 @@
+use super::*;
+use tempfile::TempDir;
+use test_log::test;
+
+#[test]
+fn test_migrate_recording_schedules_no_recording_dir() {
+    let config = config::Config::default();
+    assert!(config.recording.basedir.is_none());
+
+    let migrated = migrate_recording_schedules(&config, &Default::default());
+    assert!(!migrated);
+}
+
+#[test]
+fn test_migrate_recording_schedules_no_schedules_json() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let recording_dir = temp_dir.as_ref().join("recording");
+    std::fs::create_dir(&recording_dir).unwrap();
+    assert!(recording_dir.is_dir());
+
+    let old_path = recording_dir.join("schedules.json");
+    assert!(!old_path.exists());
+
+    let mut config = config::Config::default();
+    config.recording.basedir = Some(recording_dir.clone());
+
+    let migrated = migrate_recording_schedules(&config, &Default::default());
+    assert!(!migrated);
+}
+
+#[test]
+fn test_migrate_recording_schedules_already_migrated() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let recording_dir = temp_dir.as_ref().join("recording");
+    std::fs::create_dir(&recording_dir).unwrap();
+    assert!(recording_dir.is_dir());
+
+    let old_path = recording_dir.join("schedules.json");
+    std::fs::write(&old_path, b"").unwrap();
+    assert!(old_path.is_file());
+
+    let new_path = recording_dir.join("schedules.v1.json");
+    std::fs::write(&new_path, b"").unwrap();
+    assert!(new_path.is_file());
+
+    let mut config = config::Config::default();
+    config.recording.basedir = Some(recording_dir.clone());
+
+    let migrated = migrate_recording_schedules(&config, &Default::default());
+    assert!(!migrated);
+}
+
+#[test]
+fn test_migrate_recording_schedules_no_epg_data() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let recording_dir = temp_dir.as_ref().join("recording");
+    std::fs::create_dir(&recording_dir).unwrap();
+    assert!(recording_dir.is_dir());
+
+    let old_path = recording_dir.join("schedules.json");
+    std::fs::write(&old_path, b"").unwrap();
+    assert!(old_path.is_file());
+
+    let new_path = recording_dir.join("schedules.v1.json");
+    assert!(!new_path.exists());
+
+    let epg_dir = temp_dir.as_ref().join("epg");
+    assert!(!epg_dir.exists());
+
+    let mut config = config::Config::default();
+    config.recording.basedir = Some(recording_dir.clone());
+
+    let migrated = migrate_recording_schedules(&config, &Default::default());
+    assert!(!migrated);
+}
+
+#[test]
+fn test_migrate_recording_schedules_no_services_json() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let recording_dir = temp_dir.as_ref().join("recording");
+    std::fs::create_dir(&recording_dir).unwrap();
+    assert!(recording_dir.is_dir());
+
+    let old_path = recording_dir.join("schedules.json");
+    std::fs::write(&old_path, b"").unwrap();
+    assert!(old_path.is_file());
+
+    let new_path = recording_dir.join("schedules.v1.json");
+    assert!(!new_path.exists());
+
+    let epg_dir = temp_dir.as_ref().join("epg");
+    std::fs::create_dir(&epg_dir).unwrap();
+    assert!(epg_dir.is_dir());
+
+    let services_json = epg_dir.join("services.json");
+    assert!(!services_json.exists());
+
+    let mut config = config::Config::default();
+    config.epg.cache_dir = Some(epg_dir.clone());
+    config.recording.basedir = Some(recording_dir.clone());
+
+    let migrated = migrate_recording_schedules(&config, &Default::default());
+    assert!(!migrated);
+}
+
+#[test]
+fn test_migrate_recording_schedules_no_such_service() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let recording_dir = temp_dir.as_ref().join("recording");
+    std::fs::create_dir(&recording_dir).unwrap();
+    assert!(recording_dir.is_dir());
+
+    let old_path = recording_dir.join("schedules.json");
+    // TODO: write test data
+    std::fs::write(&old_path, include_bytes!("schedules.json")).unwrap();
+    assert!(old_path.is_file());
+
+    let new_path = recording_dir.join("schedules.v1.json");
+    assert!(!new_path.exists());
+
+    let epg_dir = temp_dir.as_ref().join("epg");
+    std::fs::create_dir(&epg_dir).unwrap();
+    assert!(epg_dir.is_dir());
+
+    let services_json = epg_dir.join("services.json");
+    std::fs::write(&services_json, b"[]").unwrap();
+    assert!(services_json.is_file());
+
+    let mut config = config::Config::default();
+    config.epg.cache_dir = Some(epg_dir.clone());
+    config.recording.basedir = Some(recording_dir.clone());
+
+    let migrated = migrate_recording_schedules(&config, &Default::default());
+    assert!(!migrated);
+}
+
+#[test]
+fn test_migrate_recording_schedules_migrated() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let recording_dir = temp_dir.as_ref().join("recording");
+    std::fs::create_dir(&recording_dir).unwrap();
+    assert!(recording_dir.is_dir());
+
+    let old_path = recording_dir.join("schedules.json");
+    // TODO: write test data
+    std::fs::write(&old_path, include_bytes!("schedules.json")).unwrap();
+    assert!(old_path.is_file());
+
+    let new_path = recording_dir.join("schedules.v1.json");
+    assert!(!new_path.exists());
+
+    let epg_dir = temp_dir.as_ref().join("epg");
+    std::fs::create_dir(&epg_dir).unwrap();
+    assert!(epg_dir.is_dir());
+
+    let services_json = epg_dir.join("services.json");
+    std::fs::write(&services_json, include_bytes!("services.json")).unwrap();
+    assert!(services_json.is_file());
+
+    let mut config = config::Config::default();
+    config.epg.cache_dir = Some(epg_dir.clone());
+    config.recording.basedir = Some(recording_dir.clone());
+
+    let migrated = migrate_recording_schedules(&config, &Default::default());
+    assert!(migrated);
+    assert!(old_path.is_file());
+    assert!(new_path.is_file());
+
+    let actual: serde_json::Value = {
+        let file = std::fs::File::open(&new_path).unwrap();
+        serde_json::from_reader(file).unwrap()
+    };
+    let expected: serde_json::Value =
+        serde_json::from_slice(include_bytes!("schedules.v1.json")).unwrap();
+    assert_eq!(actual, expected);
+}

--- a/mirakc/src/migrate/v4/tests/schedules.json
+++ b/mirakc/src/migrate/v4/tests/schedules.json
@@ -1,0 +1,24 @@
+[
+  {
+    "state": "scheduled",
+    "program": {
+      "id": 10000100001,
+      "start_at": 0,
+      "duration": 0,
+      "scrambled": false,
+      "name": null,
+      "description": null,
+      "extended": null,
+      "video": null,
+      "audios": null,
+      "genres": null,
+      "series": null,
+      "event_group": null
+    },
+    "options": {
+      "priority": 0,
+      "preFilters": [],
+      "postFilters": []
+    }
+  }
+]

--- a/mirakc/src/migrate/v4/tests/schedules.v1.json
+++ b/mirakc/src/migrate/v4/tests/schedules.v1.json
@@ -1,0 +1,39 @@
+[
+  {
+    "state": "scheduled",
+    "program": {
+      "id": 10000100001,
+      "start_at": 0,
+      "duration": 0,
+      "scrambled": false,
+      "name": null,
+      "description": null,
+      "extended": null,
+      "video": null,
+      "audios": null,
+      "genres": null,
+      "series": null,
+      "event_group": null
+    },
+    "service": {
+      "id": 100001,
+      "type": 1,
+      "logoId": -1,
+      "remoteControlKeyId": 0,
+      "name": "test",
+      "channel": {
+        "name": "test",
+        "type": "GR",
+        "channel": "1",
+        "extra_args": "",
+        "services": [],
+        "excluded_services": []
+      }
+    },
+    "options": {
+      "priority": 0,
+      "preFilters": [],
+      "postFilters": []
+    }
+  }
+]

--- a/mirakc/src/migrate/v4/tests/services.json
+++ b/mirakc/src/migrate/v4/tests/services.json
@@ -1,0 +1,20 @@
+[
+  [
+    100001,
+    {
+      "id": 100001,
+      "type": 1,
+      "logoId": -1,
+      "remoteControlKeyId": 0,
+      "name": "test",
+      "channel": {
+        "name": "test",
+        "type": "GR",
+        "channel": "1",
+        "extra_args": "",
+        "services": [],
+        "excluded_services": []
+      }
+    }
+  ]
+]


### PR DESCRIPTION
Migrate existing data to the new data format automatically if mirakc is a **release** binary.

The `migrate` sub-command has been added for manual migration.

Older data files will be held even after the auto-migration finishes successfully.  Those should be removed manually.

Closes #2209.