### PR TITLE
fix(mirakc): clear buffer after errors

### DIFF
--- a/mirakc-core/src/epg/eit_feeder.rs
+++ b/mirakc-core/src/epg/eit_feeder.rs
@@ -254,6 +254,7 @@ where
                         }
                         Err(err) => {
                             tracing::warn!(%err, %channel, "Ignore broken EIT section");
+                            json.clear();
                             continue;
                         }
                     };
@@ -268,6 +269,7 @@ where
                         num_sections += 1;
                     } else {
                         tracing::warn!(%channel, section.table_id, "Invalid table_id");
+                        json.clear();
                     }
                 }
                 _ = &mut timeout => {


### PR DESCRIPTION
tsduckのtspコマンドを使ってeitinjectして遊んでいたときに発覚しました。

read_lineに与えるバッファがクリアされていないため、一度Invalid tableなどのエラーが起こって無視すると複数行がJSONデシリアライザに渡されることになり、エラーが出続けていました。

通常の運用だと問題は起こりにくいかもしれないですが、そういうパケットが届く可能性もあるため、修正PRを作りました。